### PR TITLE
DataPoints Can now be added and deleted from UI

### DIFF
--- a/Settings/MainControl.xaml
+++ b/Settings/MainControl.xaml
@@ -1,0 +1,68 @@
+﻿<UserControl
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:SimHub.MQTTPublisher.Settings"
+             xmlns:styles="clr-namespace:SimHub.Plugins.Styles;assembly=SimHub.Plugins" xmlns:View="clr-namespace:SimHub.MQTTPublisher.Settings" x:Class="SimHub.MQTTPublisher.Settings.MainControl"
+             mc:Ignorable="d"
+             d:DesignHeight="800" d:DesignWidth="850">
+    
+
+    <Grid>
+        <Rectangle Fill="#FF333333" Height="30" Stroke="Transparent" StrokeThickness="0,0,0,0" Margin="-5,-6,-50,0" VerticalAlignment="Top" HorizontalAlignment="Stretch"/>
+        <TabControl x:Name="MainTapControl" HorizontalAlignment="Left" Height="805" VerticalAlignment="Top" Width="855" Background="Transparent" Margin="-5,-5,0,0">
+            <TabControl.Resources>
+                <ResourceDictionary>
+
+                    <Style x:Key="ColoredTabsStyle" TargetType="{x:Type TabItem}">
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="{x:Type TabItem}">
+                                    <Border x:Name="Border" BorderThickness="0,0,0,0" CornerRadius="0,0,0,0"
+                                        Padding="20,5,20,5" Margin="0,0,0,0" BorderBrush="Gainsboro">
+                                        <ContentPresenter x:Name="ContentSite" ContentSource="Header" />
+                                    </Border>
+                                    <ControlTemplate.Triggers>
+                                        <Trigger Property="IsSelected" Value="False">
+                                            <Setter Property="TextElement.FontSize" TargetName="ContentSite" Value="14" />
+                                            <Setter Property="TextElement.FontFamily" TargetName="ContentSite" Value="Segoe UI" />
+                                            <Setter Property="TextElement.FontWeight" TargetName="ContentSite" Value="SemiBold" />
+
+                                            <Setter Property="TextElement.Foreground" TargetName="ContentSite" Value="#FFAAAAAA" />
+                                            <Setter TargetName="Border" Property="Background" Value="#FF333333" />
+                                        </Trigger>
+                                        <Trigger Property="IsMouseOver" Value="True">
+                                            <Setter Property="TextElement.FontSize" TargetName="ContentSite" Value="14" />
+                                            <Setter Property="TextElement.FontFamily" TargetName="ContentSite" Value="Segoe UI" />
+                                            <Setter Property="TextElement.FontWeight" TargetName="ContentSite" Value="SemiBold" />
+
+                                            <Setter Property="TextElement.Foreground" TargetName="ContentSite" Value="White" />
+                                            <Setter TargetName="Border" Property="Background" Value="#FF333333" />
+                                        </Trigger>
+                                        <Trigger Property="IsSelected" Value="True">
+                                            <Setter Property="TextElement.FontSize" TargetName="ContentSite" Value="14" />
+                                            <Setter Property="TextElement.FontFamily" TargetName="ContentSite" Value="Segoe UI" />
+                                            <Setter Property="TextElement.FontWeight" TargetName="ContentSite" Value="SemiBold" />
+
+                                            <Setter Property="TextElement.Foreground" TargetName="ContentSite" Value="Black" />
+                                            <Setter TargetName="Border" Property="Background" Value="White" />
+                                        </Trigger>
+                                    </ControlTemplate.Triggers>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                </ResourceDictionary>
+            </TabControl.Resources>
+
+            <TabItem Header="Settings" Style="{StaticResource ColoredTabsStyle}">
+                <Grid>
+                    <View:SimHubMQTTPublisherPluginUI x:Name="SettingsView"/>
+                </Grid>
+            </TabItem>
+        </TabControl>
+
+
+    </Grid>
+</UserControl>

--- a/Settings/MainControl.xaml
+++ b/Settings/MainControl.xaml
@@ -61,6 +61,11 @@
                     <View:SimHubMQTTPublisherPluginUI x:Name="SettingsView"/>
                 </Grid>
             </TabItem>
+            <TabItem Header="Properties" Style="{StaticResource ColoredTabsStyle}">
+                <Grid>
+                    <View:PropertiesSettingUI x:Name="PropertiesView"/>
+                </Grid>
+            </TabItem>
         </TabControl>
 
 

--- a/Settings/MainControl.xaml.cs
+++ b/Settings/MainControl.xaml.cs
@@ -25,7 +25,7 @@ namespace SimHub.MQTTPublisher.Settings
             InitializeComponent();
 
             SettingsView.Init(plugin);
-            
+            PropertiesView.Init(plugin);
         }
     }
 }

--- a/Settings/MainControl.xaml.cs
+++ b/Settings/MainControl.xaml.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace SimHub.MQTTPublisher.Settings
+{
+    /// <summary>
+    /// Interaction logic for MainControl.xaml
+    /// </summary>
+    public partial class MainControl : UserControl
+    {
+        public MainControl(SimHubMQTTPublisherPlugin plugin)
+        {
+            InitializeComponent();
+
+            SettingsView.Init(plugin);
+            
+        }
+    }
+}

--- a/Settings/PropertiesSettingUI.xaml
+++ b/Settings/PropertiesSettingUI.xaml
@@ -1,0 +1,44 @@
+﻿<UserControl x:Class="SimHub.MQTTPublisher.Settings.PropertiesSettingUI"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:viewmodels="clr-namespace:SimHub.MQTTPublisher.ViewModels"
+             xmlns:styles="clr-namespace:SimHub.Plugins.Styles;assembly=SimHub.Plugins"
+             mc:Ignorable="d" d:DataContext="{d:DesignInstance viewmodels:PropertiesModel}"
+             d:DesignHeight="800" d:DesignWidth="850">
+    <Grid>
+        <styles:SHSection>
+            <ListView x:Name="LvPropertys" HorizontalAlignment="Left" Height="710" Margin="10,85,0,0" VerticalAlignment="Top" Width="830" ItemsSource="{Binding Path=Properties}" SelectionChanged="LvPropertys_SelectionChanged" SelectionMode="Single">
+            <ListView.View>
+                <GridView AllowsColumnReorder="False">
+                    <GridViewColumn Width="320">
+                        <GridViewColumn.Header>
+                            <TextBlock Text="Field" Width="320"/>
+                        </GridViewColumn.Header>
+                        <GridViewColumn.CellTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding Path=Name}" Width="320"/>
+                            </DataTemplate>
+                        </GridViewColumn.CellTemplate>
+                    </GridViewColumn>
+                    <GridViewColumn Width="510">
+                        <GridViewColumn.Header>
+                            <TextBlock Text="Track" Width="510"/>
+                        </GridViewColumn.Header>
+                        <GridViewColumn.CellTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding Path=Property}" Width="510"/>
+                            </DataTemplate>
+                        </GridViewColumn.CellTemplate>
+                    </GridViewColumn>
+                </GridView>
+            </ListView.View>
+        </ListView>
+        </styles:SHSection>
+        <styles:SHButtonPrimary x:Name="BtnDelete" Content="Delete" Margin="0,10,10,0" VerticalAlignment="Top" HorizontalAlignment="Right" Width="100" Click="BtnDelete_Click"/>
+        <styles:SHButtonPrimary x:Name="BtnEdit" Content="Edit" Margin="0,10,115,0" VerticalAlignment="Top" HorizontalAlignment="Right" Width="100" Click="BtnEdit_Click"/>
+        <styles:SHButtonPrimary x:Name="BtnAdd" Content="Add" Margin="0,10,220,0" VerticalAlignment="Top" HorizontalAlignment="Right" Width="100" Click="BtnAdd_Click"/>
+
+    </Grid>
+</UserControl>

--- a/Settings/PropertiesSettingUI.xaml.cs
+++ b/Settings/PropertiesSettingUI.xaml.cs
@@ -81,7 +81,7 @@ namespace SimHub.MQTTPublisher.Settings
             if (item == null)
                 return;
 
-            var result = MessageBox.Show("Do you really want to delete the data point with field " + item.Name + " and property " + item.Property + " with ", "Are you sure?", MessageBoxButton.OKCancel, MessageBoxImage.Warning);
+            var result = MessageBox.Show("Do you really want to Delete this Property?\n\n" + item.Name + "\n" + item.Property, "Are you sure?", MessageBoxButton.OKCancel, MessageBoxImage.Warning);
 
             if (result == MessageBoxResult.OK)
             {
@@ -95,12 +95,36 @@ namespace SimHub.MQTTPublisher.Settings
 
         private void BtnEdit_Click(object sender, RoutedEventArgs e)
         {
+            var item = GetSelectedIndex();
 
+            if (item == null)
+                return;
+
+            var editModel = new EditingPropertyModel()
+            {
+                IsEditing = true,
+                Mother = Model,
+                Row = item
+            };
+            
+            var window = new PropertyEditWindow();
+            window.Init(Plugin, editModel);
+            window.Show();
         }
 
         private void BtnAdd_Click(object sender, RoutedEventArgs e)
         {
+            var addModel = new EditingPropertyModel()
+            {
+                IsEditing = false,
+                Mother = Model,
+                Name = "",
+                Property = ""
+            };
 
+            var window = new PropertyEditWindow();
+            window.Init(Plugin, addModel);
+            window.Show();
         }
     }
 }

--- a/Settings/PropertiesSettingUI.xaml.cs
+++ b/Settings/PropertiesSettingUI.xaml.cs
@@ -1,0 +1,106 @@
+﻿using SimHub.MQTTPublisher.ViewModels;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace SimHub.MQTTPublisher.Settings
+{
+    /// <summary>
+    /// Interaction logic for PropertiesSettingUI.xaml
+    /// </summary>
+    public partial class PropertiesSettingUI : UserControl
+    { 
+        private SimHubMQTTPublisherPlugin Plugin { get; set; }
+
+        private PropertiesModel Model { get; set; }
+
+
+        public PropertiesSettingUI()
+        {
+            InitializeComponent();
+            BtnEdit.IsEnabled = false;
+            BtnDelete.IsEnabled = false;
+        }
+
+        internal void Init(SimHubMQTTPublisherPlugin plugin)
+        {
+            Plugin = plugin;
+            this.Model = new PropertiesModel()
+            {
+                Properties = new System.Collections.ObjectModel.ObservableCollection<PropertyRow>(),
+            };
+
+            var dataPoints = Plugin.PropertiesSettings.DataPoints;
+            foreach (var point in dataPoints)
+            {
+                Model.Properties.Add(new PropertyRow(point.Key, point.Value));
+            }
+
+            this.DataContext = this.Model;
+        }
+
+        private void LvPropertys_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            GetSelectedIndex();
+        }
+
+        private PropertyRow GetSelectedIndex()
+        {
+            object item = LvPropertys.SelectedItem;
+
+            if (item is PropertyRow)
+            {
+                BtnDelete.IsEnabled = true;
+                BtnEdit.IsEnabled = true;
+                return item as PropertyRow;
+            }
+            else
+            {
+                BtnEdit.IsEnabled = false;
+                BtnDelete.IsEnabled = false;
+            }
+
+            return null;
+        }
+
+        private void BtnDelete_Click(object sender, RoutedEventArgs e)
+        {
+            var item = GetSelectedIndex();
+
+            if (item == null)
+                return;
+
+            var result = MessageBox.Show("Do you really want to delete the data point with field " + item.Name + " and property " + item.Property + " with ", "Are you sure?", MessageBoxButton.OKCancel, MessageBoxImage.Warning);
+
+            if (result == MessageBoxResult.OK)
+            {
+                var dataPoints = Plugin.PropertiesSettings.DataPoints;
+                if (dataPoints.Remove(item.Name))
+                    Model.Properties.Remove(item);
+                else
+                    MessageBox.Show("Something went wrong deleting the " + item.Name + ". It might have been already deleted", "Something went wrong", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        private void BtnEdit_Click(object sender, RoutedEventArgs e)
+        {
+
+        }
+
+        private void BtnAdd_Click(object sender, RoutedEventArgs e)
+        {
+
+        }
+    }
+}

--- a/Settings/PropertyEditWindow.xaml
+++ b/Settings/PropertyEditWindow.xaml
@@ -1,0 +1,42 @@
+﻿<Window x:Class="SimHub.MQTTPublisher.Settings.PropertyEditWindow"
+            xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+            xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+            xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+            xmlns:local="clr-namespace:SimHub.MQTTPublisher.Settings"
+            xmlns:styles="clr-namespace:SimHub.Plugins.Styles;assembly=SimHub.Plugins"
+            xmlns:viewmodels="clr-namespace:SimHub.MQTTPublisher.ViewModels"
+            mc:Ignorable="d" d:DataContext="{d:DesignInstance viewmodels:EditingPropertyModel}"
+            Height="220" Width="415" ResizeMode="NoResize" Title="{Binding WindowTitle}">
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="400" />
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="auto" />
+            <RowDefinition Height="auto" />
+            <RowDefinition Height="auto" />
+            <RowDefinition Height="auto" />
+            <RowDefinition Height="auto" />
+        </Grid.RowDefinitions>
+
+        <Label Grid.Row="0">Field</Label>
+        <TextBox Margin="4" Grid.Row="1" Text="{Binding Path=Name}"></TextBox>
+        <Label Grid.Row="2">Property</Label>
+        <TextBox Margin="4" Grid.Row="3" Text="{Binding Path=Property}"></TextBox>
+
+        <Grid Grid.Row="5" Margin="4,10">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="auto" />
+            </Grid.RowDefinitions>
+
+            <styles:SHButtonPrimary x:Name="BtnAgree" Margin="4"  Grid.Row="0" Grid.Column="0" Click="BtnAgree_Click" Content="{Binding AgreeLabel}"/>
+            <styles:SHButtonPrimary x:Name="BtnCancel" Margin="4"  Grid.Row="0" Grid.Column="1" Click="BtnCancel_Click" Content="Cancel"/>
+        </Grid>
+        
+    </Grid>
+</Window>

--- a/Settings/PropertyEditWindow.xaml.cs
+++ b/Settings/PropertyEditWindow.xaml.cs
@@ -1,0 +1,110 @@
+﻿using SimHub.MQTTPublisher.ViewModels;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace SimHub.MQTTPublisher.Settings
+{
+    /// <summary>
+    /// Interaction logic for PropertyEditWindow.xaml
+    /// </summary>
+    public partial class PropertyEditWindow : Window
+    {
+        private SimHubMQTTPublisherPlugin Plugin;
+
+        private EditingPropertyModel Model;
+
+        public PropertyEditWindow()
+        {
+            InitializeComponent();
+        }
+
+        internal void Init(SimHubMQTTPublisherPlugin plugin, EditingPropertyModel model)
+        {
+            Plugin = plugin;
+            Model = model;
+
+            this.DataContext = Model;
+        }
+
+        private void BtnAgree_Click(object sender, RoutedEventArgs e)
+        {
+            if (Model.IsEditing)
+            {
+                if (Model.Row.Name != Model.Name)
+                {
+                    if (!CheckIfNameAvailable())
+                        return;
+
+                    Plugin.PropertiesSettings.DataPoints.Remove(Model.Row.Name);
+
+                    AddField();
+
+                    Model.Row.Name = Model.Name;
+                    Model.Row.Property = Model.Property;
+                }
+                else
+                {
+                    Plugin.PropertiesSettings.DataPoints[Model.Name] = Model.Property;
+
+                    Model.Row.Property = Model.Property;
+                }
+            }
+            else
+            {
+                if (!CheckIfNameAvailable())
+                    return;
+
+                AddField();
+                Model.Mother.Properties.Add(new PropertyRow(Model.Name, Model.Property));
+            }
+
+
+            this.Close();
+        }
+
+        private bool CheckIfNameAvailable()
+        {
+            var keys = Plugin.PropertiesSettings.DataPoints.Keys;
+
+            string lowerCaseName = Model.Name.ToLower();
+
+            foreach (var key in keys)
+            {
+                //We won't allow keys with the same spelling but different case
+                if (key.ToLower() == lowerCaseName)
+                {
+                    MessageBox.Show("Field name " + Model.Name + " is already in use. Pick another Name", "Field Name Collision", MessageBoxButton.OK, MessageBoxImage.Warning);
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private void AddField()
+        {
+            //Field has to be added to previousValues prior to being added to DataPoints,
+            //else there is a chance for the DataUpdate trying to update our entry and then fail on the check for the previous value
+            Plugin.previousValues.Add(Model.Name, "");
+
+            Plugin.PropertiesSettings.DataPoints.Add(Model.Name, Model.Property);
+        }
+
+        private void BtnCancel_Click(object sender, RoutedEventArgs e)
+        {
+            this.Close();
+        }
+    }
+}

--- a/Settings/SimHubMQTTPublisherPluginUI.xaml.cs
+++ b/Settings/SimHubMQTTPublisherPluginUI.xaml.cs
@@ -8,9 +8,13 @@ namespace SimHub.MQTTPublisher.Settings
     /// </summary>
     public partial class SimHubMQTTPublisherPluginUI : UserControl
     {
-        public SimHubMQTTPublisherPluginUI(SimHubMQTTPublisherPlugin simHubMQTTPublisherPlugin)
+        public SimHubMQTTPublisherPluginUI()
         {
             InitializeComponent();
+        }
+
+        internal void Init(SimHubMQTTPublisherPlugin simHubMQTTPublisherPlugin)
+        {
             SimHubMQTTPublisherPlugin = simHubMQTTPublisherPlugin;
 
             this.Model = new SimHubMQTTPublisherPluginUIModel()
@@ -28,9 +32,9 @@ namespace SimHub.MQTTPublisher.Settings
             this.DataContext = Model;
         }
 
-        private SimHubMQTTPublisherPluginUIModel Model { get; }
+        private SimHubMQTTPublisherPluginUIModel Model { get; set; }
 
-        private SimHubMQTTPublisherPlugin SimHubMQTTPublisherPlugin { get; }
+        private SimHubMQTTPublisherPlugin SimHubMQTTPublisherPlugin { get; set; }
 
         private void Apply_Settings(object sender, System.Windows.RoutedEventArgs e)
         {

--- a/SimHub.MQTTPublisher.csproj
+++ b/SimHub.MQTTPublisher.csproj
@@ -75,7 +75,9 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="UIAutomationProvider" />
     <Reference Include="WindowsBase" />
+    <Reference Include="WindowsFormsIntegration" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Payload\Car.cs" />
@@ -83,6 +85,9 @@
     <Compile Include="Payload\TrackInformation.cs" />
     <Compile Include="Settings\PropertiesSettingUI.xaml.cs">
       <DependentUpon>PropertiesSettingUI.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Settings\PropertyEditWindow.xaml.cs">
+      <DependentUpon>PropertyEditWindow.xaml</DependentUpon>
     </Compile>
     <Compile Include="Settings\SimHubMQTTPublisherPluginUI.xaml.cs">
       <DependentUpon>SimHubMQTTPublisherPluginUI.xaml</DependentUpon>
@@ -98,6 +103,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="ViewModels\EditingPropertyModel.cs" />
     <Compile Include="ViewModels\PropertiesModel.cs" />
     <Compile Include="ViewModels\SimHubMQTTPublisherPluginUIModel.cs" />
   </ItemGroup>
@@ -108,6 +114,10 @@
       <ContainsDesignTimeResources>true</ContainsDesignTimeResources>
     </Page>
     <Page Include="Settings\PropertiesSettingUI.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Settings\PropertyEditWindow.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -137,7 +147,7 @@
   <PropertyGroup>
     <PostBuildEvent>copy /Y "$(TargetDir)$(ProjectName).dll" "c:\Program Files (x86)\SimHub\$(ProjectName).dll"
 copy /Y "$(TargetDir)MQTTnet.dll" "c:\Program Files (x86)\SimHub\MQTTnet.dll"</PostBuildEvent>
-  </PropertyGroup> 
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/SimHub.MQTTPublisher.csproj
+++ b/SimHub.MQTTPublisher.csproj
@@ -45,7 +45,7 @@
     </Reference>
     <Reference Include="MahApps.Metro">
       <HintPath>Libs\MahApps.Metro.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="MQTTnet, Version=3.1.2.0, Culture=neutral, PublicKeyToken=b69712f52770c0a7, processorArchitecture=MSIL">
       <HintPath>packages\MQTTnet.3.1.2\lib\net461\MQTTnet.dll</HintPath>
@@ -62,7 +62,7 @@
     </Reference>
     <Reference Include="SimHub.Plugins">
       <HintPath>Libs\SimHub.Plugins.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -84,6 +84,9 @@
     <Compile Include="Settings\SimHubMQTTPublisherPluginUI.xaml.cs">
       <DependentUpon>SimHubMQTTPublisherPluginUI.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Settings\MainControl.xaml.cs">
+      <DependentUpon>MainControl.xaml</DependentUpon>
+    </Compile>
     <Compile Include="SimHubMQTTPublisherPlugin.cs" />
     <Compile Include="SimHubMQTTPublisherPluginSettings.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -101,6 +104,10 @@
       <ContainsDesignTimeResources>true</ContainsDesignTimeResources>
     </Page>
     <Page Include="Settings\SimHubMQTTPublisherPluginUI.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Settings\MainControl.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/SimHub.MQTTPublisher.csproj
+++ b/SimHub.MQTTPublisher.csproj
@@ -81,6 +81,9 @@
     <Compile Include="Payload\Car.cs" />
     <Compile Include="Payload\PayloadRoot.cs" />
     <Compile Include="Payload\TrackInformation.cs" />
+    <Compile Include="Settings\PropertiesSettingUI.xaml.cs">
+      <DependentUpon>PropertiesSettingUI.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Settings\SimHubMQTTPublisherPluginUI.xaml.cs">
       <DependentUpon>SimHubMQTTPublisherPluginUI.xaml</DependentUpon>
     </Compile>
@@ -95,6 +98,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="ViewModels\PropertiesModel.cs" />
     <Compile Include="ViewModels\SimHubMQTTPublisherPluginUIModel.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -102,6 +106,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
       <ContainsDesignTimeResources>true</ContainsDesignTimeResources>
+    </Page>
+    <Page Include="Settings\PropertiesSettingUI.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Settings\SimHubMQTTPublisherPluginUI.xaml">
       <SubType>Designer</SubType>
@@ -129,7 +137,7 @@
   <PropertyGroup>
     <PostBuildEvent>copy /Y "$(TargetDir)$(ProjectName).dll" "c:\Program Files (x86)\SimHub\$(ProjectName).dll"
 copy /Y "$(TargetDir)MQTTnet.dll" "c:\Program Files (x86)\SimHub\MQTTnet.dll"</PostBuildEvent>
-  </PropertyGroup>
+  </PropertyGroup> 
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/SimHubMQTTPublisherPlugin.cs
+++ b/SimHubMQTTPublisherPlugin.cs
@@ -184,7 +184,7 @@ namespace SimHub.MQTTPublisher
         /// <returns></returns>
         public System.Windows.Controls.Control GetWPFSettingsControl(PluginManager pluginManager)
         {
-            return new SimHubMQTTPublisherPluginUI(this);
+            return new MainControl(this);
         }
 
         /// <summary>

--- a/SimHubMQTTPublisherPlugin.cs
+++ b/SimHubMQTTPublisherPlugin.cs
@@ -28,7 +28,7 @@ namespace SimHub.MQTTPublisher
 
         private MqttFactory mqttFactory;
         private IMqttClient mqttClient;
-        private Dictionary<string, string> previousValues = new Dictionary<string, string>();
+        internal Dictionary<string, string> previousValues = new Dictionary<string, string>();
 
         /// <summary>
         /// Instance of the current plugin manager

--- a/SimHubMQTTPublisherPlugin.cs
+++ b/SimHubMQTTPublisherPlugin.cs
@@ -89,26 +89,16 @@ namespace SimHub.MQTTPublisher
             {
                 var payload = new Dictionary<string, object>();
                 var telemetry = new Dictionary<string, object>();
-                object value;
-                string stringValue;
 
-                payload["time"] = System.DateTimeOffset.Now.ToUnixTimeMilliseconds();
+                payload["time"] = DateTimeOffset.Now.ToUnixTimeMilliseconds();
 
                 foreach (var d in PropertiesSettings.DataPoints)
                 {
-                    if ($"{d.Key}" == "CurrentLapTime")
-                    {
-                        value = data.NewData.CurrentLapTime.TotalMilliseconds;
-                    }
-                    else if ($"{d.Key}" == "LastLapTime")
-                    {
-                        value = data.NewData.LastLapTime.TotalMilliseconds;
-                    }
-                    else
-                    {
-                        value = pluginManager.GetPropertyValue(d.Value);
-                    }
-                    stringValue = $"{value}";
+                    object value = pluginManager.GetPropertyValue(d.Value);
+                    if (value is TimeSpan timeSpan)
+                        value = timeSpan.TotalMilliseconds;
+
+                    string stringValue = $"{value}";
                     if (stringValue != previousValues[d.Key])
                     {
                         telemetry[d.Key] = value;

--- a/SimHubMQTTPublisherPluginSettings.cs
+++ b/SimHubMQTTPublisherPluginSettings.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace SimHub.MQTTPublisher
 {
@@ -26,5 +27,33 @@ namespace SimHub.MQTTPublisher
     {
         public Guid UserId { get; set; } = Guid.NewGuid();
 
+    }
+
+    public class SimHubMQTTPublisherPluginProperties
+    {
+        public Dictionary<string, string> DataPoints { get; set; }
+
+        public SimHubMQTTPublisherPluginProperties LoadDefaults()
+        {
+            DataPoints = new Dictionary<string, string>(){
+                { "Rpms", "DataCorePlugin.GameData.Rpms" },
+                { "SpeedKmh", "DataCorePlugin.GameData.SpeedKmh"},
+                { "Clutch", "DataCorePlugin.GameData.Clutch"},
+                { "Throttle", "DataCorePlugin.GameData.Throttle"},
+                { "Brake", "DataCorePlugin.GameData.Brake"},
+                { "Gear", "DataCorePlugin.GameData.Gear"},
+                { "CurrentLap", "DataCorePlugin.GameData.CurrentLap"},
+                { "CarCoordinates", "DataCorePlugin.GameData.CarCoordinates"},
+                { "CurrentLapTime", "DataCorePlugin.GameData.CurrentLapTime"},
+                { "SteeringAngle", "ExtraInputProperties.SteeringAngle"},
+                { "HandBrake", "DataCorePlugin.GameData.Handbrake"},
+                { "TrackPositionPercent", "DataCorePlugin.GameData.TrackPositionPercent"},
+                { "CarCoordinates01", "DataCorePlugin.GameData.CarCoordinates01" },
+                { "CarCoordinates02", "DataCorePlugin.GameData.CarCoordinates02" },
+                { "CarCoordinates03", "DataCorePlugin.GameData.CarCoordinates03" },
+            };
+
+            return this;
+        }
     }
 }

--- a/ViewModels/EditingPropertyModel.cs
+++ b/ViewModels/EditingPropertyModel.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SimHub.MQTTPublisher.ViewModels
+{
+    internal class EditingPropertyModel : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private PropertiesModel _mother;
+
+        private PropertyRow _row;
+
+        private string _name;
+
+        private string _property;
+
+        private bool _isEditing;
+
+        public PropertiesModel Mother
+        {
+            get => _mother;
+            set
+            {
+                _mother = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public PropertyRow Row
+        {
+            get => _row;
+            set
+            {
+                _row = value;
+                OnPropertyChanged();
+
+                Name = value.Name;
+                Property = value.Property;
+            }
+        }
+
+        public string Name
+        {
+            get => _name;
+
+            set
+            {
+                _name = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public string Property
+        {
+            get => _property;
+
+            set
+            {
+                _property = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public bool IsEditing
+        {
+            get => _isEditing;
+            set
+            {
+                _isEditing = value;
+                OnPropertyChanged();
+            }
+        }
+
+        protected void OnPropertyChanged([CallerMemberName] string propertyName = "")
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        public string WindowTitle
+        {
+            get
+            {
+                if (IsEditing)
+                    return "Edit";
+                else
+                    return "Add";
+            }
+        }
+
+        public string AgreeLabel
+        {
+            get
+            {
+                if (IsEditing)
+                    return "Save";
+                else
+                    return "Add";
+            }
+        }
+    }
+}

--- a/ViewModels/PropertiesModel.cs
+++ b/ViewModels/PropertiesModel.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SimHub.MQTTPublisher.ViewModels
+{
+    internal class PropertiesModel: INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public ObservableCollection<PropertyRow> _properties = new ObservableCollection<PropertyRow>();
+
+        public ObservableCollection<PropertyRow> Properties
+        {
+            get => _properties;
+            
+            set
+            {
+                _properties = value;
+                OnPropertyChanged();
+            }
+        }
+
+        protected void OnPropertyChanged([CallerMemberName] string propertyName = "")
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+
+    internal class PropertyRow : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private string _name;
+
+        private string _property;
+
+        public string Name
+        {
+            get => _name;
+
+            set
+            {
+                _name = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public string Property
+        {
+            get => _property;
+
+            set
+            {
+                _property = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public PropertyRow() { }
+
+        public PropertyRow(string name, string property)
+        {
+            _name = name;
+            _property = property;
+        }
+
+        protected void OnPropertyChanged([CallerMemberName] string propertyName = "")
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}


### PR DESCRIPTION
-A TabControl has been added to the UI, with the Setting put into the default Tab, the DataPoints into the second
-Added Properties page to Add, Edit and Delete DataPoint Entries
-Added Window to Add/Edit a DataPoint
-DataPoints are now stored in their own Settings, and saved/load on shutdown/startup
-Properties of type "TimeSpan" (for example CurrentLapTime and LastLapTime) are automatically converted to Milliseconds